### PR TITLE
Support for the K Computer

### DIFF
--- a/lib/BOAST/Language/Expression.rb
+++ b/lib/BOAST/Language/Expression.rb
@@ -56,9 +56,9 @@ module BOAST
       return oper.string(op1, op2, return_type) unless oper.kind_of?(String)
       s = ""
       if op1 then
-        s << "(" if (oper == "*" or oper == "/" or true)
+        s << "(" if (oper == "*" or oper == "/")
         s << op1.to_s
-        s << ")" if (oper == "*" or oper == "/" or true)
+        s << ")" if (oper == "*" or oper == "/")
       end
       s << " " unless oper == "++" or oper == "."
       s << oper unless ( oper == "&" and lang == FORTRAN )

--- a/lib/BOAST/Language/Expression.rb
+++ b/lib/BOAST/Language/Expression.rb
@@ -64,9 +64,9 @@ module BOAST
       s << oper unless ( oper == "&" and lang == FORTRAN )
       s << " " unless oper == "." or oper == "&" or ( oper == "*" and op1.nil? )
       if op2 then
-        s << "(" if (oper == "*" or oper == "/" or oper == "-" or true)
+        s << "(" if (oper == "*" or oper == "/" or oper == "-")
         s << op2.to_s
-        s << ")" if (oper == "*" or oper == "/" or oper == "-" or true)
+        s << ")" if (oper == "*" or oper == "/" or oper == "-")
       end
       return s
     end

--- a/lib/BOAST/Language/Expression.rb
+++ b/lib/BOAST/Language/Expression.rb
@@ -56,17 +56,17 @@ module BOAST
       return oper.string(op1, op2, return_type) unless oper.kind_of?(String)
       s = ""
       if op1 then
-        s << "(" if (oper == "*" or oper == "/")
+        s << "(" if (oper == "*" or oper == "/" or true)
         s << op1.to_s
-        s << ")" if (oper == "*" or oper == "/")
+        s << ")" if (oper == "*" or oper == "/" or true)
       end
       s << " " unless oper == "++" or oper == "."
       s << oper unless ( oper == "&" and lang == FORTRAN )
       s << " " unless oper == "." or oper == "&" or ( oper == "*" and op1.nil? )
       if op2 then
-        s << "(" if (oper == "*" or oper == "/" or oper == "-")
+        s << "(" if (oper == "*" or oper == "/" or oper == "-" or true)
         s << op2.to_s
-        s << ")" if (oper == "*" or oper == "/" or oper == "-")
+        s << ")" if (oper == "*" or oper == "/" or oper == "-" or true)
       end
       return s
     end

--- a/lib/BOAST/Language/Operators.rb
+++ b/lib/BOAST/Language/Operators.rb
@@ -61,7 +61,7 @@ module BOAST
   class Plus < Operator
 
     def Plus.string(arg1, arg2, return_type)
-      return " +#{arg2}"
+      return " +(#{arg2})"
     end
 
   end
@@ -245,7 +245,7 @@ module BOAST
       end
   
       def basic_usage(arg1, arg2)
-        return "#{arg1} + #{arg2}" 
+        return "#{arg1} + (#{arg2})" 
       end
   
     end

--- a/lib/BOAST/Runtime/Compilers.rb
+++ b/lib/BOAST/Runtime/Compilers.rb
@@ -57,7 +57,11 @@ module BOAST
       probes.each { |p|
         cflags += " #{p.cflags}" if p.respond_to?(:cflags)
       }
-      cflags += " -march=#{get_model}"
+      if RUBY_PLATFORM == "sparc64-linux" then
+        cflags += " -mcpu=#{get_model}"
+      else
+        cflags += " -march=#{get_model}"
+      end if
       cflags += " -fPIC #{includes}"
       cflags += " -DHAVE_NARRAY_H" if narray_path
       cflags += " -I/usr/local/k1tools/include" if @architecture == MPPA
@@ -119,7 +123,11 @@ module BOAST
     def setup_fortran_compiler(options, runner, probes)
       f_compiler = options[:FC]
       fcflags = options[:FCFLAGS]
-      fcflags += " -march=#{get_model}"
+      if RUBY_PLATFORM == "sparc64-linux" then
+        fcflags += " -mcpu=#{get_model}"
+      else
+        fcflags += " -march=#{get_model}"
+      end if
       fcflags += " -fPIC"
       fcflags += " -fno-second-underscore" if f_compiler == 'g95'
       if (options[:openmp] or options[:OPENMP]) and @lang == FORTRAN and not disable_openmp then
@@ -174,7 +182,11 @@ module BOAST
 
     def setup_linker(options, probes)
       ldflags = options[:LDFLAGS]
-      ldflags += " -march=#{get_model}"
+      if RUBY_PLATFORM == "sparc64-linux" then
+        ldflags += " -mcpu=#{get_model}"
+      else
+        ldflags += " -march=#{get_model}"
+      end if
       ldflags += " -L#{RbConfig::CONFIG["libdir"]}"
       if RbConfig::CONFIG["ENABLE_SHARED"] != "no" then
         ldflags += " #{RbConfig::CONFIG["LIBRUBYARG"]}"
@@ -200,6 +212,9 @@ module BOAST
       if OS.mac? then
         ldshared = "-dynamic -bundle"
         ldshared_flags = "-Wl,-undefined,dynamic_lookup -Wl,-multiply_defined,suppress"
+      elsif RUBY_PLATFORM == "sparc64-linux" then
+        ldshared = "-shared"
+        ldshared_flags = "-Wl,-Bsymbolic -Wl,-z,relro -rdynamic -Wl,-export-dynamic"
       else
         ldshared = "-shared"
         ldshared_flags = "-Wl,-Bsymbolic-functions -Wl,-z,relro -rdynamic -Wl,-export-dynamic"

--- a/lib/BOAST/Runtime/Compilers.rb
+++ b/lib/BOAST/Runtime/Compilers.rb
@@ -214,7 +214,7 @@ module BOAST
         ldshared_flags = "-Wl,-undefined,dynamic_lookup -Wl,-multiply_defined,suppress"
       elsif RUBY_PLATFORM == "sparc64-linux" then
         ldshared = "-shared"
-        ldshared_flags = "-Wl,-Bsymbolic -Wl,-z,relro -rdynamic -Wl,-export-dynamic"
+        ldshared_flags = "-Wl,-Bsymbolic -Wl,-z,relro -Wl,-export-dynamic"
       else
         ldshared = "-shared"
         ldshared_flags = "-Wl,-Bsymbolic-functions -Wl,-z,relro -rdynamic -Wl,-export-dynamic"

--- a/lib/BOAST/Runtime/Config.rb
+++ b/lib/BOAST/Runtime/Config.rb
@@ -32,7 +32,10 @@ module BOAST
     "gfortran" => "-fopenmp",
     "ifort" => "-openmp",
     "g++" => "-fopenmp",
-    "icpc" => "-openmp"
+    "icpc" => "-openmp",
+    "frt" => "-Kopenmp",
+    "fcc" => "-Kopenmp",
+    "FCC" => "-Kopenmp"
   }
 
   @@run_options = [


### PR DESCRIPTION
I've modified BOAST to support the Fujitsu compilers we use on the K computer. I choose the guard of `RUBY_PLATFORM == "sparc64-linux"` for these changes.

1. `-march` does not exist for the Fujitsu compiler, so I've replaced it with `-mcpu`. 

2. The K computer has a really old version of LD (2.17), which does not have `-Bsymbolic-functions`. Using just `-Bsymbolic` seems to work.

3. I added openmp flags for the fujitsu compiler's which are called `frt', `fcc`, and `FCC`. 

4. BOAST has some guards in place to prevent writing expressions like y = x - - 3. But there are no guards in place for y = x + -3. The fujitsu compiler strictly requires the parenthesis around (-3) in this case.

One final note, the K computer does not have `/proc/cpuinfo`. Is there some file that specifies which flags BOAST actually checks for? If so, perhaps I could manually check what our chips support.