### PR TITLE
Add comment generation to procedures.

### DIFF
--- a/lib/BOAST/Language/Variable.rb
+++ b/lib/BOAST/Language/Variable.rb
@@ -184,6 +184,7 @@ module BOAST
     attr_writer :alignment
     attr_accessor :replace_constant
     attr_accessor :force_replace_constant
+    attr_reader :comment
 
     def alignment
       return @type.total_size if vector? and lang == FORTRAN and not @alignment
@@ -270,6 +271,7 @@ module BOAST
     # @option properties [Boolean] :replace_constant specifies that for scalar constants this variable should be replaced by its constant value. For constant arrays, the value of the array will be replaced if the index can be determined at evaluation.
     # @option properties [Boolean] :deferred_shape for Fortran interface generation mainly see Fortran documentation
     # @option properties [Boolean] :optional for Fortran interface generation mainly see Fortran documentation
+    # @option properties [#to_s] :comment text comment to print with autodocumentation format
     def initialize(name, type, properties={})
       @name = name.to_s
       @direction = properties[:direction] or @direction = properties[:dir]
@@ -286,6 +288,7 @@ module BOAST
       @reference = properties[:reference]
       @force_replace_constant = false
       @replace_constant = properties[:replace_constant]
+      @comment = properties[:comment]
 
       if @texture and lang == CL then
         @sampler = Variable::new("sampler_#{name}", CustomType,:type_name => "sampler_t" ,:replace_constant => false, :constant => "CLK_NORMALIZED_COORDS_FALSE | CLK_ADDRESS_NONE | CLK_FILTER_NEAREST")
@@ -625,6 +628,9 @@ module BOAST
         @constant.shape = self if dimension? && @constant.kind_of?(ConstArray)
         s << " = #{@constant}"
         s << @type.suffix if !dimension? && @type
+      end
+      if @properties[:comment] and comment_type == "SPHINX" then
+          s << " ! #{@comment}"
       end
       s << finalize
       output.print s

--- a/lib/BOAST/Runtime/Config.rb
+++ b/lib/BOAST/Runtime/Config.rb
@@ -53,6 +53,7 @@ module BOAST
     private_boolean_state_accessor :executable
     private_boolean_state_accessor :keep_temp
     private_state_accessor :fortran_line_length
+    private_state_accessor :comment_type
     private_state_accessor :synchro
   end
 
@@ -63,6 +64,7 @@ module BOAST
   boolean_state_accessor :executable
   boolean_state_accessor :keep_temp
   state_accessor         :fortran_line_length
+  state_accessor         :comment_type
   state_accessor :synchro
   default_state_getter :verbose,             false
   default_state_getter :debug_source,        false
@@ -71,6 +73,7 @@ module BOAST
   default_state_getter :executable,          false
   default_state_getter :keep_temp,           false
   default_state_getter :fortran_line_length, 72
+  default_state_getter :comment_type,        "DOXYGEN"
   default_state_getter :synchro,             "MUTEX"
 
   module_function

--- a/test/Language/Procedure.rb
+++ b/test/Language/Procedure.rb
@@ -159,4 +159,74 @@ int32_t minimum(const int32_t a, const int32_t b){
 EOF
   end
 
+  def test_doc
+    a = Int( :a, :dir => :in, :comment => "This is an input value" )
+    b = Int( :b, :dir => :inout, :comment => "This is an inout value" )
+    c = Int( :c , :comment => "This is a returned value")
+    p = Procedure("minimum", [a,b], :return => c, :comment => ["This is a procedure", "with two comments"]) { pr c === Ternary( a < b, a, b) }
+    block = lambda { pr p }
+    set_comment_type("DOXYGEN")
+    set_lang(FORTRAN)
+    assert_subprocess_output( <<EOF, "", &block )
+!> \\brief This is a procedure
+!! with two comments
+!! \\param [in] a This is an input value
+!! \\param [in,out] b This is an inout value
+!! \\return c This is a returned value
+integer(kind=4) FUNCTION minimum(a, b)
+  integer, parameter :: wp=kind(1.0d0)
+  integer(kind=4), intent(in) :: a
+  integer(kind=4), intent(inout) :: b
+  integer(kind=4) :: c
+  c = merge(a, b, a < b)
+  minimum = c
+END FUNCTION minimum
+EOF
+    set_lang(C)
+    assert_subprocess_output( <<EOF, "", &block )
+/**
+ *  \\brief This is a procedure
+ *  with two comments
+ *  \\param [in] a This is an input value
+ *  \\param [in,out] b This is an inout value
+ *  \\return c This is a returned value
+ */
+int32_t minimum(const int32_t a, int32_t * b){
+  int32_t c;
+  c = (a < (*b) ? a : (*b));
+  return c;
+}
+EOF
+    set_comment_type("SPHINX")
+    set_lang(FORTRAN)
+    assert_subprocess_output( <<EOF, "", &block )
+integer(kind=4) FUNCTION minimum(a, b)
+  !> This is a procedure
+  !> with two comments
+  integer, parameter :: wp=kind(1.0d0)
+  integer(kind=4), intent(in) :: a ! This is an input value
+  integer(kind=4), intent(inout) :: b ! This is an inout value
+  integer(kind=4) :: c ! This is a returned value
+  c = merge(a, b, a < b)
+  minimum = c
+END FUNCTION minimum
+EOF
+#for now C+Sphinx = Doxygen, to be postprocessed with Breathe
+    set_lang(C)
+    assert_subprocess_output( <<EOF, "", &block )
+/**
+ *  \\brief This is a procedure
+ *  with two comments
+ *  \\param [in] a This is an input value
+ *  \\param [in,out] b This is an inout value
+ *  \\return c This is a returned value
+ */
+int32_t minimum(const int32_t a, int32_t * b){
+  int32_t c;
+  c = (a < (*b) ? a : (*b));
+  return c;
+}
+EOF
+  end
+
 end


### PR DESCRIPTION
Can be configured in the global configuration file to generate Doxygen or Sphinx comments for procedures, arguments and returns
For C, Sphinx mode generates Doxygen comments, to be postprocessed with breathe
Comments are to be put in the declaration of the variable and procedure, making boast a bit more self documented.

examples : check test_doc in test/Language/Procedure.rb
